### PR TITLE
Fixed issue when trying to add item in mobile view (full-screen dialog)

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
@@ -238,7 +238,11 @@
 				},
 				onCancel: cancelCallback
 			}
-			Namics.GenericMultifieldDialogHandler.openDialog(dialog);
+			try {
+				Namics.GenericMultifieldDialogHandler.openDialog(dialog);
+			} catch(error) {
+				cancelCallback();
+			}
 		},
 
 		/**

--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldDialogHandler.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldDialogHandler.js
@@ -34,7 +34,7 @@
 		 */
 		self.openDialog = function(dialog) {
 			if (!Granite.author.DialogFrame.currentDialog) {
-				return;
+				throw new Error("Parent dialog can't be null");
 			}
 
 			// push old dialog to parent
@@ -97,7 +97,8 @@
 		function _performCloseDialog() {
 			// execute function after fading effect has finished
 			setTimeout(function waitToClose() {
-				// make sure that Granite.author.DialogFrame.currentDialog has ben cleared
+				// make sure that Granite.author.DialogFrame.currentDialog has ben
+				// cleared
 				if (Granite.author.DialogFrame.currentDialog) {
 					setTimeout(waitToClose, 50);
 				}
@@ -107,7 +108,8 @@
 				// open parent dialog if it exists
 				if (parentDialog) {
 					Granite.author.DialogFrame.openDialog(parentDialog);
-					// remove custom backdrop on the last dialog after fading effect has finished
+					// remove custom backdrop on the last dialog after fading effect has
+					// finished
 					if (self.parentDialogs && self.parentDialogs.length == 0) {
 						setTimeout(function() {
 							_removeCustomBackdrop();


### PR DESCRIPTION
Adding an item on the generic multifield doesn't work if the dialog is
opened in full-screen within the mobile view. The draw-back was that the
item is created before opening the dialog but never got deleted if it
fails.

The fix is to delete the item again if an error occurs during opening the
dialog.