### PR TITLE
Fixed listing wrong items when using multisite

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
@@ -79,7 +79,7 @@
 			}).done(function(data) {
 				that.ol.empty();
 				$.each(data,function(key){
-					if (typeof data[key] === 'object'){
+					if (typeof data[key] === 'object' && !Array.isArray(data[key]) && data[key] !== undefined && data[key]["jcr:primaryType"] !== undefined){
 
 						if(that.itemNameDisplayStrategy === "pageTitle"){
 							//use the jcr:title from a page


### PR DESCRIPTION
When listing the items within the generic multifield, it was only checked if they are a JavaScript object. Unfortunately the array is an object too...

The fix is to explicitly check on !Array.isArray(...) and to also add a check on the property "jcr:primaryType" to make sure that only JCR nodes are being displayed.