### PR TITLE
Fixed bug of losing previously entered text after closing a generic m…

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldDialogHandler.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldDialogHandler.js
@@ -15,8 +15,8 @@
      */
     ns.GenericMultifieldDialogHandler = (function () {
         var self = {};
-        var DIALOG_SELECTOR = "coral-dialog.cq-Dialog";
-        var DIALOG_CONTENT_SELECTOR = DIALOG_SELECTOR + " coral-dialog-content.coral-Dialog-content";
+        var DIALOG_SELECTOR = "coral-dialog";
+        var DIALOG_CONTENT_SELECTOR = DIALOG_SELECTOR + " coral-dialog-content";
 
         /**
          * Array of parent dialogs.


### PR DESCRIPTION
The previously entered text is being saved before opening a new generic multifield dialog and restored after closing it (using a CSS selector). This selector has changed from AEM 6.3 to 6.4 and that's the reason why the text was lost.

The fix was to remove the classes from the selector and just leave the HTML elements. Probably this will be more stable than using CSS classes that could change depending on the Coral UI version used.