### PR TITLE
Adapted generic multifield so that it can be used within page properties

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/css/genericmultifield.css
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/css/genericmultifield.css
@@ -117,10 +117,7 @@
     background-color: #f0f0f0;
 }
 
-/* show the genericmultifield backdrop only when original backdrop is not visible */
-.cq-dialog-backdrop[style*='display:none'] ~ .cq-dialog-backdrop-genericmultifield,
-.cq-dialog-backdrop[style*='display: none'] ~ .cq-dialog-backdrop-genericmultifield,
-.cq-dialog-backdrop:not(.is-open) ~ .cq-dialog-backdrop-genericmultifield {
+.cq-dialog-backdrop-genericmultifield {
     z-index: 920;
     display: block;
     position: fixed;
@@ -137,4 +134,9 @@
     opacity: 1;
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
     filter: alpha(opacity=0);
+}
+
+/* hide the genericmultifield backdrop if original backdrop is visible */
+.cq-dialog-backdrop:not([style*='display:none']):not([style*='display: none']) ~ .cq-dialog-backdrop-genericmultifield {
+    display: none;
 }

--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
@@ -240,6 +240,7 @@
             try {
                 Namics.GenericMultifieldDialogHandler.openDialog(dialog);
             } catch (error) {
+                console.error(error);
                 if ($.isFunction(cancelCallback)) {
                     cancelCallback();
                 }

--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldHelper.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldHelper.js
@@ -56,6 +56,14 @@
                 $customBackdrop.remove();
             });
             $customBackdrop.css("opacity", "0");
+
+            // remove backdrop after a maximum of 1s if no transition event was fired
+            setTimeout(function waitToClose() {
+                // remove backdrop
+                if ($customBackdrop.length) {
+                    $customBackdrop.remove();
+                }
+            }, 1000);
         }
 
     }

--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldHelper.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/GenericMultifieldHelper.js
@@ -9,11 +9,53 @@
      */
     ns.Helper = {
 
+        CUSTOM_BACKDROP_CLASS: "cq-dialog-backdrop-genericmultifield",
+        CUSTOM_BACKDROP_SELECTOR: ".cq-dialog-backdrop-genericmultifield",
+
         manglePath: function (path) {
             if (!path) {
                 return;
             }
             return path.replace(/\/(\w+):(\w+)/g, "/_$1_$2");
+        },
+
+        /**
+         * Displays the dialog backdrop over the content
+         *
+         * @private
+         */
+        createCustomBackdrop: function () {
+            var $customBackdrop = $(ns.Helper.CUSTOM_BACKDROP_SELECTOR),
+                $originalBackdrop = $(".cq-dialog-backdrop");
+
+            // don't create backdrop if it already exists
+            if ($customBackdrop.length) {
+                return;
+            }
+
+            // create backdrop
+            $customBackdrop = $('<div class="' + ns.Helper.CUSTOM_BACKDROP_CLASS + '"></div>');
+            if ($originalBackdrop.length) {
+                $customBackdrop.insertAfter($originalBackdrop);
+            } else {
+                $("body").append($customBackdrop);
+            }
+
+            // backdrop has CSS transition to fade in
+            $customBackdrop.css("opacity", "1");
+        },
+
+        /**
+         * Hides the dialog backdrop over the content
+         *
+         * @private
+         */
+        removeCustomBackdrop: function () {
+            var $customBackdrop = $(ns.Helper.CUSTOM_BACKDROP_SELECTOR);
+            $customBackdrop.one("transitionend", function () {
+                $customBackdrop.remove();
+            });
+            $customBackdrop.css("opacity", "0");
         }
 
     }


### PR DESCRIPTION
The assumption of the generic multifield dialog was that it's always used on top of other dialogs (as was the case in classic UI). Since touch UI the page properties are not within a dialog anymore. That's why following modifications had to be made:
- removed check for mandatory existing parent dialog
- modified backdrop handling to fit both cases (component dialog and page properties)