### PR TITLE
Increase robustness if arbitrary intermediate nodes has been crated b…

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
@@ -93,7 +93,13 @@
                                 for (var i = 0; i < propertyValue.length - 1; i += 1) {
                                     parent = parent[propertyValue[i]];
                                 }
-                                propertyValue = parent[propertyValue[propertyValue.length - 1]];
+
+                                if (parent !== undefined){
+                                    propertyValue = parent[propertyValue[propertyValue.length - 1]];
+                                } else {
+                                    propertyValue = key;
+                                }
+
                             } else {
                                 propertyValue = data[key][that.itemNameProperty];
                             }


### PR DESCRIPTION
Increase robustness if arbitrary intermediate nodes has been crated but itemNameProperty is missing. In this case now the node name of the intermediate node will be used for displaying in the dialog.

See https://jira.namics.com/browse/SLEVO-1815